### PR TITLE
Adds PR #1 and better version code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nativescript hook plugin to maintain native app version
 
-This plugin takes the `version` property from `package.json` and puts on the specific platform resources: `AndroidManifest.xml` file for the Android sources, and `Info.plist` for iOS sources.
+This plugin takes the `version` and `versionNumber` properties from `package.json` and puts on the specific platform resources: `AndroidManifest.xml` file for the Android sources, and `Info.plist` for iOS sources.
 
 This plugin is mainly a fork of [jacargentina/nativescript-dev-version](https://github.com/jacargentina/nativescript-dev-version), with the great ideas from [speigg/nativescript-dev-version](https://github.com/speigg/nativescript-dev-version/tree/patch-1) and [simplec-dev/nativescript-dev-version](https://github.com/simplec-dev/nativescript-dev-version).
 
@@ -18,7 +18,8 @@ Then, specify and maintain the desired release version on the `./package.json` f
 {
   "nativescript": {
     "id": "org.nativescript.MySampleApp",
-    "version": "1.2.3"
+    "version": "1.2.3",
+    "versionNumber": "1"
     ...
   },
   ...
@@ -29,9 +30,26 @@ or:
 
 ```json
 {
-  "version": "1.2.3"
+  "version": "1.2.3",
+  "versionNumber": "1"
   ...
 }
 ```
 
-When running `tns prepare ...` the hooks will take care of the native resources, and your app will get the `1.2.3` version number!
+When running `tns prepare ...` the hooks will take care of the native resources.
+
+On iOS, your `Info.plist` will get:
+
+```
+<key>CFBundleShortVersionString</key>
+<string>1.2.3</string>
+<key>CFBundleVersion</key>
+<string>1</string>
+```
+
+On Android, `AndroidManifest.xml` will have:
+
+```
+<manifest
+  (...) android:versionCode="10203001" android:versionName="1.2.3"
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nativescript hook plugin to maintain native app version
 
-This plugin takes the `version` property from `package.json` (either `./package.json` or `./app/package.json`) and puts on the specific platform resources: `AndroidManifest.xml` file for the Android sources, and `Info.plist` for iOS sources.
+This plugin takes the `version` property from `package.json` and puts on the specific platform resources: `AndroidManifest.xml` file for the Android sources, and `Info.plist` for iOS sources.
 
 This plugin is mainly a fork of [jacargentina/nativescript-dev-version](https://github.com/jacargentina/nativescript-dev-version), with the great ideas from [speigg/nativescript-dev-version](https://github.com/speigg/nativescript-dev-version/tree/patch-1) and [simplec-dev/nativescript-dev-version](https://github.com/simplec-dev/nativescript-dev-version).
 
@@ -25,12 +25,12 @@ Then, specify and maintain the desired release version on the `./package.json` f
 }
 ```
 
-or in `./app/package.json`:
+or:
 
 ```json
 {
-  ...
   "version": "1.2.3"
+  ...
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This plugin takes the `version` and `versionNumber` properties from `package.jso
 
 This plugin is mainly a fork of [jacargentina/nativescript-dev-version](https://github.com/jacargentina/nativescript-dev-version), with the great ideas from [speigg/nativescript-dev-version](https://github.com/speigg/nativescript-dev-version/tree/patch-1) and [simplec-dev/nativescript-dev-version](https://github.com/simplec-dev/nativescript-dev-version).
 
+Compatible with NS 6.
+
 ## How to use
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-Nativescript hook plugin to maintain native app version
-=======================================================
+# Nativescript hook plugin to maintain native app version and bump version code / bundle version
 
-This plugin just takes the `nativescript.version` property from `package.json` and puts on the specific platform resources: `AndroidManifest.xml` file for the Android sources, and `Info.plist` for iOS sources.
+This plugin takes the `version` property from `package.json` (either `./package.json` or `./app/package.json`) and puts on the specific platform resources: `AndroidManifest.xml` file for the Android sources, and `Info.plist` for iOS sources.
 
-How to use
-----------
+This plugin is mainly a fork of [jacargentina/nativescript-dev-version](https://github.com/jacargentina/nativescript-dev-version), with the great ideas from [speigg/nativescript-dev-version](https://github.com/speigg/nativescript-dev-version/tree/patch-1) and [simplec-dev/nativescript-dev-version](https://github.com/simplec-dev/nativescript-dev-version).
+
+## How to use
+
 ```
 $ tns plugin add nativescript-dev-version
 ```
 
 The above command installs this module and installs the necessary NativeScript hooks.
 
-Then, specify and maintain the desired release version on the `package.json` file under the `nativescript.version` property, for example:
+Then, specify and maintain the desired release version on the `./package.json` file under the `nativescript.version` property, for example:
 
 ```json
 {
@@ -24,5 +25,13 @@ Then, specify and maintain the desired release version on the `package.json` fil
 }
 ```
 
-When running `tns prepare ...` the hooks will take care of the native resources, and your app will get the `1.2.3` version number!
+or in `./app/package.json`:
 
+```json
+{
+  ...
+  "version": "1.2.3"
+}
+```
+
+When running `tns prepare ...` the hooks will take care of the native resources, and your app will get the `1.2.3` version number!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nativescript hook plugin to maintain native app version and bump version code / bundle version
+# Nativescript hook plugin to maintain native app version
 
 This plugin takes the `version` property from `package.json` (either `./package.json` or `./app/package.json`) and puts on the specific platform resources: `AndroidManifest.xml` file for the Android sources, and `Info.plist` for iOS sources.
 

--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -3,71 +3,68 @@ var AndroidManifest = require('androidmanifest');
 var iOSPList = require('plist');
 
 module.exports = function($logger, $projectData, hookArgs) {
-    var appPackage = require($projectData.projectFilePath);
-    var appVersion =
-        (appPackage.nativescript && appPackage.nativescript.version) ||
-        appPackage.version;
-    let appVersionNumber =
-        (appPackage.nativescript && appPackage.nativescript.versionNumber) ||
-        appPackage.versionNumber;
-    if (!appVersion) {
-        $logger.warn(
-            'Nativescript version is not defined. Skipping set native package version.'
-        );
-        return;
-    }
-
-    var platformsData = getPlatformsData($injector);
-    var platform = (
-        hookArgs.platform ||
-        (hookArgs.prepareData && hookArgs.prepareData.platform)
-    ).toLowerCase();
-    $logger.info(`Platform: ${platform}`);
-
-    var platformData = platformsData.getPlatformData(platform);
-    $logger.info(
-        `platformData.configurationFilePath: ${
-            platformData.configurationFilePath
-        }`
+  var appPackage = require($projectData.projectFilePath);
+  var appVersion =
+    (appPackage.nativescript && appPackage.nativescript.version) ||
+    appPackage.version;
+  let appVersionNumber =
+    (appPackage.nativescript && appPackage.nativescript.versionNumber) ||
+    appPackage.versionNumber;
+  if (!appVersion) {
+    $logger.warn(
+      'Nativescript version is not defined. Skipping set native package version.'
     );
-    if (platform == 'android') {
-        var manifest = new AndroidManifest().readFile(
-            platformData.configurationFilePath
-        );
+    return;
+  }
 
-        // transforms e.g. "1.2.3" into 102003.
-        let versionCode = appVersion
-            .split('.')
-            .reduce(
-                (acc, v, i, a) =>
-                    acc + v * Math.pow(10, (a.length - i - 1) * 2),
-                0
-            );
+  var platformsData = getPlatformsData($injector);
+  var platform = (
+    hookArgs.platform ||
+    (hookArgs.prepareData && hookArgs.prepareData.platform)
+  ).toLowerCase();
+  $logger.info(`Platform: ${platform}`);
 
-        if (appVersionNumber) {
-            versionCode = versionCode * 100 + appVersionNumber;
-        }
+  var platformData = platformsData.getPlatformData(platform);
+  $logger.info(
+    `platformData.configurationFilePath: ${platformData.configurationFilePath}`
+  );
+  if (platform == 'android') {
+    var manifest = new AndroidManifest().readFile(
+      platformData.configurationFilePath
+    );
 
-        manifest.$('manifest').attr('android:versionCode', versionCode);
-        manifest.$('manifest').attr('android:versionName', appVersion);
-        manifest.writeFile(platformData.configurationFilePath);
-    } else if (platform == 'ios') {
-        var plist = iOSPList.parse(
-            fs.readFileSync(platformData.configurationFilePath, 'utf8')
-        );
-        plist.CFBundleShortVersionString = appVersion;
-        plist.CFBundleVersion = appVersionNumber;
-        fs.writeFileSync(
-            platformData.configurationFilePath,
-            iOSPList.build(plist)
-        );
+    // transforms e.g. "1.2.3" into 102003.
+    let versionCode = appVersion
+      .split('.')
+      .reduce(
+        (acc, v, i, a) => acc + v * Math.pow(10, (a.length - i - 1) * 2),
+        0
+      );
+
+    if (appVersionNumber) {
+      versionCode =
+        versionCode * 100 +
+        (appVersionNumber < 10 ? '0' : '') + // left pad appVersionNumber
+        appVersionNumber;
     }
+
+    manifest.$('manifest').attr('android:versionCode', versionCode);
+    manifest.$('manifest').attr('android:versionName', appVersion);
+    manifest.writeFile(platformData.configurationFilePath);
+  } else if (platform == 'ios') {
+    var plist = iOSPList.parse(
+      fs.readFileSync(platformData.configurationFilePath, 'utf8')
+    );
+    plist.CFBundleShortVersionString = appVersion;
+    plist.CFBundleVersion = appVersionNumber;
+    fs.writeFileSync(platformData.configurationFilePath, iOSPList.build(plist));
+  }
 };
 
 function getPlatformsData($injector) {
-    try {
-        return $injector.resolve('platformsData');
-    } catch (err) {
-        return $injector.resolve('platformsDataService');
-    }
+  try {
+    return $injector.resolve('platformsData');
+  } catch (err) {
+    return $injector.resolve('platformsDataService');
+  }
 }

--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -1,57 +1,73 @@
-const fs = require('fs');
-const Promise = require('bluebird');
-const AndroidManifest = require('androidmanifest');
-const iOSPList = require('plist');
+var fs = require('fs');
+var AndroidManifest = require('androidmanifest');
+var iOSPList = require('plist');
 
-module.exports = function dev($logger, $projectData) {
-    const appPackage = require($projectData.projectFilePath);
-    const appVersion =
+module.exports = function($logger, $projectData, hookArgs) {
+    var appPackage = require($projectData.projectFilePath);
+    var appVersion =
         (appPackage.nativescript && appPackage.nativescript.version) ||
         appPackage.version;
     let appVersionNumber =
         (appPackage.nativescript && appPackage.nativescript.versionNumber) ||
         appPackage.versionNumber;
     if (!appVersion) {
-        $logger.warn('Nativescript version is not defined. Skipping set native package version.');
+        $logger.warn(
+            'Nativescript version is not defined. Skipping set native package version.'
+        );
         return;
     }
-    const platformService = $injector.resolve('platformService');
-    const platformsData = $injector.resolve('platformsData');
-    return Promise.each(
-        platformService.getPreparedPlatforms($projectData),
-        (platform) => {
-            const platformData = platformsData.getPlatformData(platform);
-            if (platform == 'android') {
-                const manifest = new AndroidManifest().readFile(platformData.configurationFilePath);
 
-                // transforms e.g. "1.2.3" into 1002003.
-                let versionCode = appVersion
-                    .split('.')
-                    .reduce(
-                        (acc, v, i, a) =>
-                            acc + v * Math.pow(10, (a.length - i - 1) * 2),
-                        0
-                    );
+    var platformsData = getPlatformsData($injector);
+    var platform = (
+        hookArgs.platform ||
+        (hookArgs.prepareData && hookArgs.prepareData.platform)
+    ).toLowerCase();
+    $logger.info(`Platform: ${platform}`);
 
-                if (appVersionNumber) {
-                    versionCode = versionCode * 100 + appVersionNumber;
-                }
-
-                manifest.$('manifest').attr('android:versionCode', versionCode);
-                manifest.$('manifest').attr('android:versionName', appVersion);
-                manifest.writeFile(platformData.configurationFilePath);
-            } else if (platform == 'ios') {
-                if (!appVersionNumber) {
-                    appVersionNumber = appVersion;
-                }
-                const plist = iOSPList.parse(fs.readFileSync(platformData.configurationFilePath, 'utf8'));
-                plist.CFBundleShortVersionString = appVersion;
-                plist.CFBundleVersion = appVersionNumber;
-                fs.writeFileSync(
-                    platformData.configurationFilePath,
-                    iOSPList.build(plist)
-                );
-            }
-        }
+    var platformData = platformsData.getPlatformData(platform);
+    $logger.info(
+        `platformData.configurationFilePath: ${
+            platformData.configurationFilePath
+        }`
     );
+    if (platform == 'android') {
+        var manifest = new AndroidManifest().readFile(
+            platformData.configurationFilePath
+        );
+
+        // transforms e.g. "1.2.3" into 102003.
+        let versionCode = appVersion
+            .split('.')
+            .reduce(
+                (acc, v, i, a) =>
+                    acc + v * Math.pow(10, (a.length - i - 1) * 2),
+                0
+            );
+
+        if (appVersionNumber) {
+            versionCode = versionCode * 100 + appVersionNumber;
+        }
+
+        manifest.$('manifest').attr('android:versionCode', versionCode);
+        manifest.$('manifest').attr('android:versionName', appVersion);
+        manifest.writeFile(platformData.configurationFilePath);
+    } else if (platform == 'ios') {
+        var plist = iOSPList.parse(
+            fs.readFileSync(platformData.configurationFilePath, 'utf8')
+        );
+        plist.CFBundleShortVersionString = appVersion;
+        plist.CFBundleVersion = appVersionNumber;
+        fs.writeFileSync(
+            platformData.configurationFilePath,
+            iOSPList.build(plist)
+        );
+    }
 };
+
+function getPlatformsData($injector) {
+    try {
+        return $injector.resolve('platformsData');
+    } catch (err) {
+        return $injector.resolve('platformsDataService');
+    }
+}

--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -5,27 +5,34 @@ var Promise = require('bluebird');
 var AndroidManifest = require('androidmanifest');
 var iOSPList = require('plist');
 
-module.exports = function ($logger, $projectData, $usbLiveSyncService) {
-	var appPackage = require($projectData.projectFilePath);	
-	if (!appPackage.nativescript || !appPackage.nativescript.version) {
-		$logger.warn('Nativescript version is not defined. Skipping set native package version.');
-		return;
-	}
-	var platformService = $injector.resolve('platformService');
-	var platformsData = $injector.resolve('platformsData');
-	return Promise.each(platformService.getPreparedPlatforms($projectData), function (platform) {
-		var platformData = platformsData.getPlatformData(platform);
-		if (platform == 'android') {
-			var manifest = new AndroidManifest().readFile(platformData.configurationFilePath)
-			manifest.$('manifest').attr('android:versionCode', appPackage.nativescript.version.replace(/\./g, ''))
-			manifest.$('manifest').attr('android:versionName', appPackage.nativescript.version);
-			manifest.writeFile(platformData.configurationFilePath);
-		}
-		else if (platform == 'ios') {
-			var plist = iOSPList.parse(fs.readFileSync(platformData.configurationFilePath, 'utf8'));
-			plist.CFBundleShortVersionString = appPackage.nativescript.version;
-			plist.CFBundleVersion = appPackage.nativescript.version;
-			fs.writeFileSync(platformData.configurationFilePath, iOSPList.build(plist));
-		}		
-	});
-}
+module.exports = function($logger, $projectData, $usbLiveSyncService) {
+  var appPackage = require($projectData.projectFilePath);
+  var appVersion = (appPackage.nativescript && appPackage.nativescript.version) || appPackage.version;
+  if (!appVersion) {
+    $logger.warn('Nativescript version is not defined. Skipping set native package version.');
+    return;
+  }
+  var platformService = $injector.resolve('platformService');
+  var platformsData = $injector.resolve('platformsData');
+  return Promise.each(platformService.getPreparedPlatforms($projectData), function(platform) {
+    var platformData = platformsData.getPlatformData(platform);
+    if (platform == 'android') {
+      var manifest = new AndroidManifest().readFile(platformData.configurationFilePath);
+
+      // transforms e.g. "1.2.3" into 1002003.
+      var versionCode = appPackage.nativescript.version.split('.').reduce((acc, v, i, a) => {
+        return acc + v * Math.pow(10, (a.length - i - 1) * 3);
+      }, 0);
+
+      manifest.$('manifest').attr('android:versionCode', versionCode);
+
+      manifest.$('manifest').attr('android:versionName', appVersion);
+      manifest.writeFile(platformData.configurationFilePath);
+    } else if (platform == 'ios') {
+      var plist = iOSPList.parse(fs.readFileSync(platformData.configurationFilePath, 'utf8'));
+      plist.CFBundleShortVersionString = appVersion;
+      plist.CFBundleVersion = appVersion;
+      fs.writeFileSync(platformData.configurationFilePath, iOSPList.build(plist));
+    }
+  });
+};

--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -1,37 +1,57 @@
-var fs = require('fs');
-var path = require('path');
-var glob = require('glob');
-var Promise = require('bluebird');
-var AndroidManifest = require('androidmanifest');
-var iOSPList = require('plist');
+const fs = require('fs');
+const Promise = require('bluebird');
+const AndroidManifest = require('androidmanifest');
+const iOSPList = require('plist');
 
-module.exports = function($logger, $projectData, $usbLiveSyncService) {
-  var appPackage = require($projectData.projectFilePath);
-  var appVersion = (appPackage.nativescript && appPackage.nativescript.version) || appPackage.version;
-  if (!appVersion) {
-    $logger.warn('Nativescript version is not defined. Skipping set native package version.');
-    return;
-  }
-  var platformService = $injector.resolve('platformService');
-  var platformsData = $injector.resolve('platformsData');
-  return Promise.each(platformService.getPreparedPlatforms($projectData), function(platform) {
-    var platformData = platformsData.getPlatformData(platform);
-    if (platform == 'android') {
-      var manifest = new AndroidManifest().readFile(platformData.configurationFilePath);
-
-      // transforms e.g. "1.2.3" into 1002003.
-      var versionCode = appVersion.split('.').reduce((acc, v, i, a) => {
-        return acc + v * Math.pow(10, (a.length - i - 1) * 3);
-      }, 0);
-
-      manifest.$('manifest').attr('android:versionCode', versionCode);
-      manifest.$('manifest').attr('android:versionName', appVersion);
-      manifest.writeFile(platformData.configurationFilePath);
-    } else if (platform == 'ios') {
-      var plist = iOSPList.parse(fs.readFileSync(platformData.configurationFilePath, 'utf8'));
-      plist.CFBundleShortVersionString = appVersion;
-      plist.CFBundleVersion = appVersion;
-      fs.writeFileSync(platformData.configurationFilePath, iOSPList.build(plist));
+module.exports = function dev($logger, $projectData) {
+    const appPackage = require($projectData.projectFilePath);
+    const appVersion =
+        (appPackage.nativescript && appPackage.nativescript.version) ||
+        appPackage.version;
+    let appVersionNumber =
+        (appPackage.nativescript && appPackage.nativescript.versionNumber) ||
+        appPackage.versionNumber;
+    if (!appVersion) {
+        $logger.warn('Nativescript version is not defined. Skipping set native package version.');
+        return;
     }
-  });
+    const platformService = $injector.resolve('platformService');
+    const platformsData = $injector.resolve('platformsData');
+    return Promise.each(
+        platformService.getPreparedPlatforms($projectData),
+        (platform) => {
+            const platformData = platformsData.getPlatformData(platform);
+            if (platform == 'android') {
+                const manifest = new AndroidManifest().readFile(platformData.configurationFilePath);
+
+                // transforms e.g. "1.2.3" into 1002003.
+                let versionCode = appVersion
+                    .split('.')
+                    .reduce(
+                        (acc, v, i, a) =>
+                            acc + v * Math.pow(10, (a.length - i - 1) * 2),
+                        0
+                    );
+
+                if (appVersionNumber) {
+                    versionCode = versionCode * 100 + appVersionNumber;
+                }
+
+                manifest.$('manifest').attr('android:versionCode', versionCode);
+                manifest.$('manifest').attr('android:versionName', appVersion);
+                manifest.writeFile(platformData.configurationFilePath);
+            } else if (platform == 'ios') {
+                if (!appVersionNumber) {
+                    appVersionNumber = appVersion;
+                }
+                const plist = iOSPList.parse(fs.readFileSync(platformData.configurationFilePath, 'utf8'));
+                plist.CFBundleShortVersionString = appVersion;
+                plist.CFBundleVersion = appVersionNumber;
+                fs.writeFileSync(
+                    platformData.configurationFilePath,
+                    iOSPList.build(plist)
+                );
+            }
+        }
+    );
 };

--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -20,12 +20,11 @@ module.exports = function($logger, $projectData, $usbLiveSyncService) {
       var manifest = new AndroidManifest().readFile(platformData.configurationFilePath);
 
       // transforms e.g. "1.2.3" into 1002003.
-      var versionCode = appPackage.nativescript.version.split('.').reduce((acc, v, i, a) => {
+      var versionCode = appVersion.split('.').reduce((acc, v, i, a) => {
         return acc + v * Math.pow(10, (a.length - i - 1) * 3);
       }, 0);
 
       manifest.$('manifest').attr('android:versionCode', versionCode);
-
       manifest.$('manifest').attr('android:versionName', appVersion);
       manifest.writeFile(platformData.configurationFilePath);
     } else if (platform == 'ios') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-version",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Installs nativescript hooks to maintain native app version (AndroidManifest.xml and Info.plist)'",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-version",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Installs nativescript hooks to maintain native app version (AndroidManifest.xml and Info.plist)'",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "androidmanifest": "^2.0.0",
-    "bluebird": "^3.4.7",
     "nativescript-hook": "^0.2.1",
     "plist": "^2.0.1"
   }


### PR DESCRIPTION
This PR is the sum of the great ideas from [speigg/nativescript-dev-version](https://github.com/speigg/nativescript-dev-version/tree/patch-1) and [simplec-dev/nativescript-dev-version](https://github.com/simplec-dev/nativescript-dev-version).

1- Read `version` from `package.json`;

2- Read `versionNumber` from `package.json`;

3.1- On iOS, your `Info.plist` will get:

```
<key>CFBundleShortVersionString</key>
<string>1.2.3</string>
<key>CFBundleVersion</key>
<string>1</string>
```

3.2- On Android, `AndroidManifest.xml` will have:

```
<manifest
  (...) android:versionCode="10203001" android:versionName="1.2.3"
```
